### PR TITLE
migrated mapbox api call to new url schema

### DIFF
--- a/src/Components/LunchMap/LunchMap.js
+++ b/src/Components/LunchMap/LunchMap.js
@@ -211,7 +211,7 @@ export class LunchMap extends Component {
           zoomControl={false}
         >
           <TileLayer
-            url="https://{s}.tiles.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoiY29kZTRtcyIsImEiOiJjaXlpeWNuaW8wMDQ0MnFuNGhocGZjMzVlIn0.QBWu9vI5AYJq68dtVIqCJg"
+            url="https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token={ACCESS_TOKEN}"
             attribution="&copy;<a href='https://www.mapbox.com/about/maps/'>Mapbox</a> &copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> <strong><a href='https://www.mapbox.com/map-feedback/' target='_blank'>Improve this map</a></strong>"
           />
           <ZoomControl position="bottomright" />


### PR DESCRIPTION
> Mapbox classic style deprecation
> As of June 1, 2020, Mapbox classic styles are no longer supported and cannot be requested.
(https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/)

TODO: The current access token does not have the right permissions to work with the new api. I don't have access to the account to which the token belongs and therefore can't create a new one. The new token would need to replace the placeholder `{ACCESS_TOKEN}`